### PR TITLE
[PFC-1691] (fix) Add definitions for additional recognised public holidays

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -74,7 +74,6 @@ months:
   - name: ANZAC Day # ANZAC DAY ACTUAL
     regions: [au_nsw, au_sa, au_tas, au_vic, au_wa]
     mday: 25
-    function: return_actual_date(date)
   - name: ANZAC Day # ANZAC DAY OBSERVED - no additional recognised
     regions: [au_act, au_nt, au_qld]
     mday: 25
@@ -167,7 +166,6 @@ months:
   - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au, au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
     mday: 25
-    function: return_actual_date(date)
   - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
     mday: 25
@@ -179,7 +177,6 @@ months:
   - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au, au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
-    function: return_actual_date(date)
   - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
     regions: [au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
@@ -306,10 +303,6 @@ methods:
       date += 2 if date.wday == 6
       date += 1 if date.wday == 0
       date
-  return_actual_date:
-    arguments: date
-    source: |
-      return date
 
 tests:
   - given:

--- a/au.yaml
+++ b/au.yaml
@@ -184,7 +184,7 @@ months:
   - name: Boxing Day # BOXING DAY OBSERVED - Only NT & TAS as they dont have an additional observed if on weekend
     regions: [au_tas, au_nt]
     mday: 26
-    observed: to_tuesday_if_sunday_or_monday_if_saturday(year)
+    observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
   - name: Proclamation Day
     regions: [au_sa]
     function: to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)

--- a/au.yaml
+++ b/au.yaml
@@ -71,17 +71,17 @@ months:
     week: 2
     wday: 1
   4:
-  - name: ANZAC Day
-    regions: [au]
+  - name: ANZAC Day # ANZAC DAY ACTUAL
+    regions: [au_nsw, au_sa, au_tas, au_vic, au_wa]
     mday: 25
-  - name: ANZAC Day
-    regions: [au_nsw, au_vic, au_qld, au_nt, au_sa, au_tas]
-    mday: 25
-    observed: to_monday_if_sunday(date)
-  - name: ANZAC Day
-    regions: [au_wa, au_act]
+  - name: ANZAC Day # ANZAC DAY OBSERVED - no additional recognised
+    regions: [au_act, au_nt, au_qld]
     mday: 25
     observed: to_monday_if_weekend(date)
+  - name: Additional public holiday for ANZAC Day # ADDITIONAL ANZAC DAY
+    regions: [au_sa, au_wa]
+    mday: 25
+    function: additional_anzac_on_monday_if_on_weekend(date)
   5:
   - name: Labour Day
     regions: [au_qld]
@@ -163,21 +163,28 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Day # CHRISTMAS DAY - All states except SA observe on 27th (and 25th) if 25th is a Sunday
-    regions: [au, au_qld, au_nsw, au_act, au_tas, au_wa, au_vic, au_nt]
+  - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
+    regions: [au, au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
+    mday: 25
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT
+    regions: [au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
+    mday: 25
+    function: additional_holiday_if_on_weekend(date)
+  - name: Christmas Day # CHRISTMAS DAY OBSERVED - Only NT as they dont have an additional observed if on weekend
+    regions: [au_nt]
     mday: 25
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
-  - name: Boxing Day
-    regions: [au_nsw, au_vic, au_qld, au_act, au_wa]
+  - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
+    regions: [au, au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
-    observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
-  - name: Additional public holiday for Boxing Day # BOXING DAY ADDITIONAL - for States that recognise both the actual day (if on weekend) and the adjusted observed day
-    regions: [au_nsw, au_vic, au_qld, au_act, au_wa]
+  - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
+    regions: [au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
-    function: additiona_boxing_day(date)
-  - name: Boxing Day
+    function: additional_holiday_if_on_weekend(date)
+  - name: Boxing Day # BOXING DAY OBSERVED - Only NT & TAS as they dont have an additional observed if on weekend
     regions: [au_tas, au_nt]
-    function: to_weekday_if_boxing_weekend_from_year(year)
+    mday: 26
+    observed: to_tuesday_if_sunday_or_monday_if_saturday(year)
   - name: Proclamation Day
     regions: [au_sa]
     function: to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)
@@ -274,18 +281,65 @@ methods:
       else
         Date.civil(year, 5, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, :third, :monday))
       end
-  additiona_boxing_day:
+  additional_holiday_if_on_weekend:
     # https://www.fairwork.gov.au/leave/public-holidays
-    # If Boxing Day falls on a weekend (Saturday / Sunday), the public holiday rates will be paid on both the weekend date and the observed date (e. Monday / Tuesday) and the additional day will use the term 'additional public holiday'.
+    # https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays/list-of-public-holidays-2021
+    # If Boxing Day/Christmas fall on a weekend (Saturday / Sunday), the public holiday rates will be paid on both the weekend date and the observed date (e. Monday / Tuesday) and the additional day will use the term 'Additional public holiday'.
     arguments: date
     source: |
       if [0,6].include?(date.wday)
+        date += 2
         date
       else
         nil
       end
+  additional_anzac_on_monday_if_on_weekend:
+    # https://www.fairwork.gov.au/leave/public-holidays
+    # https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays/list-of-public-holidays-2021
+    # SA and WA recognise additional anzac holidays on monday if on the weekend
+    arguments: date
+    source: |
+      return nil unless [0,6].include?(date.wday)
+      date += 2 if date.wday == 6
+      date += 1 if date.wday == 0
+      date
 
 tests:
+  - given:
+      date: '2020-04-25'
+      regions: ["au_act"]
+    expect:
+      name: 'ANZAC Day'
+  - given:
+      date: '2020-04-25'
+      regions: ["au_qld"]
+    expect:
+      name: 'ANZAC Day'
+  - given:
+      date: '2021-04-27'
+      regions: ["au_wa"]
+    expect:
+      name: 'Additional public holiday for ANZAC Day'
+  - given:
+      date: '2021-12-25'
+      regions: ["au_qld"]
+    expect:
+      name: 'Christmas Day'
+  - given:
+      date: '2021-12-27'
+      regions: ["au_qld"]
+    expect:
+      name: 'Additional public holiday for Christmas Day'
+  - given:
+      date: '2021-12-26'
+      regions: ["au_qld"]
+    expect:
+      name: 'Boxing Day'
+  - given:
+      date: '2021-12-28'
+      regions: ["au_qld"]
+    expect:
+      name: 'Additional public holiday for Boxing Day'
   - given:
       date: '2013-10-07'
       regions: ["au_qld"]

--- a/au.yaml
+++ b/au.yaml
@@ -74,6 +74,7 @@ months:
   - name: ANZAC Day # ANZAC DAY ACTUAL
     regions: [au_nsw, au_sa, au_tas, au_vic, au_wa]
     mday: 25
+    function: return_actual_date(date)
   - name: ANZAC Day # ANZAC DAY OBSERVED - no additional recognised
     regions: [au_act, au_nt, au_qld]
     mday: 25
@@ -166,6 +167,7 @@ months:
   - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au, au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
     mday: 25
+    function: return_actual_date(date)
   - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
     mday: 25
@@ -177,6 +179,7 @@ months:
   - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au, au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
+    function: return_actual_date(date)
   - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
     regions: [au_act, au_nsw, au_qld, au_sa, au_vic, au_wa]
     mday: 26
@@ -303,6 +306,10 @@ methods:
       date += 2 if date.wday == 6
       date += 1 if date.wday == 0
       date
+  return_actual_date:
+    arguments: date
+    source: |
+      return date
 
 tests:
   - given:


### PR DESCRIPTION
Still PFC-1691 fixing definitions for xmas and ANZAC day for 2020/2021 while we're here