### PR TITLE
fixed USA holiday tests

### DIFF
--- a/us.yaml
+++ b/us.yaml
@@ -921,12 +921,12 @@ tests:
       name: "Christmas Eve"
 
   - given:
-      date: ['2021-12-27', '2022-12-26', '2027-12-27']
+      date: ['2021-12-24', '2022-12-24', '2027-12-23']
       regions: ["us"]
     expect:
       holiday: false
   - given:
-      date: ['2021-12-24', '2022-12-26', '2027-12-24']
+      date: ['2021-12-27', '2022-12-26', '2027-12-24']
       regions: ["us"]
       options: ["observed"]
     expect:


### PR DESCRIPTION
the test_background_sync_job_test is failing when trying to merge payaus change for removing melbourne holiday

changed the 2021, 2022, and 2027 test for USA christmas day