### PR TITLE
Revert "removed Melbourne Cup holiday from au_vic region and fixed a few tests"

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -162,6 +162,10 @@ months:
     regions: [au_tas_north]
     wday: 1
     week: 1
+  - name: Melbourne Cup Day
+    regions: [au_vic_melbourne, au_vic]
+    week: 1
+    wday: 2
   12:
   - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa, au_nt]
@@ -313,7 +317,7 @@ tests:
     expect:
       name: 'ANZAC Day'
   - given:
-      date: '2021-04-26'
+      date: '2021-04-27'
       regions: ["au_wa"]
     expect:
       name: 'Additional public holiday for ANZAC Day'
@@ -336,7 +340,7 @@ tests:
       date: '2021-12-28'
       regions: ["au_qld"]
     expect:
-      name: 'Additional public holiday Boxing Day'
+      name: 'Additional public holiday for Boxing Day'
   - given:
       date: '2013-10-07'
       regions: ["au_qld"]
@@ -453,7 +457,7 @@ tests:
       date: '2015-12-26'
       regions: ["au_tas"]
     expect:
-      name: 'Boxing Day'
+      holiday: false
   - given:
       date: '2015-11-14'
       regions: ["au_qld_brisbane"]
@@ -463,12 +467,12 @@ tests:
       date: '2015-12-26'
       regions: ["au_nt"]
     expect:
-      name: 'Boxing Day'
+      holiday: false
   - given:
       date: '2016-12-27'
       regions: ["au_sa"]
     expect:
-      name: 'Additional public holiday for Christmas Day'
+      name: 'Proclamation Day'
   - given:
       date: '2016-12-25'
       regions: ["au_nt"]
@@ -519,22 +523,17 @@ tests:
       date: '2014-11-04'
       regions: ["au_vic_melbourne"]
     expect:
-      holiday: false
+      name: 'Melbourne Cup Day'
   - given:
       date: '2015-11-03'
       regions: ["au_vic_melbourne"]
     expect:
-      holiday: false
+      name: 'Melbourne Cup Day'
   - given:
       date: '2019-11-05'
       regions: ["au_vic"]
     expect:
-      holiday: false
-  - given:
-      date: '2021-11-02'
-      regions: ["au_vic"]
-    expect:
-      holiday: false
+      name: 'Melbourne Cup Day'
   - given:
       date: '2015-10-02'
       regions: ["au_vic"]

--- a/us.yaml
+++ b/us.yaml
@@ -926,7 +926,7 @@ tests:
     expect:
       holiday: false
   - given:
-      date: ['2021-12-24', '2022-12-26', '2027-12-24']
+      date: ['2021-12-24', '2022-12-23', '2027-12-24']
       regions: ["us"]
       options: ["observed"]
     expect:


### PR DESCRIPTION
Reverts TandaHQ/definitions#22