### PR TITLE
Pfc 3593/au nyd and christmas changes

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -188,7 +188,7 @@ months:
   - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
-  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day to monday instead of tuesday
+  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day to after christmas day even if it falls on Monday
     regions: [au_nt, au_sa]
     mday: 26
     function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
@@ -339,13 +339,13 @@ methods:
       else
         date
       end
-  to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday: # NT has boxing day on tuesday if on monday instead
+  to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday: # NT/SA has boxing day on tuesday if on monday instead
     arguments: date
     source: |
-      if date.wday == 6
+      if [6,0].include?(date.wday)
         date += 2
         date
-      elsif [0,1].include?(date.wday)
+      elsif date.wday == 1
         date += 1
         date
       else

--- a/au.yaml
+++ b/au.yaml
@@ -370,6 +370,15 @@ methods:
       else
         date
       end
+  to_tuesday_if_monday: # SA moves boxing day to after christmas day instead
+    arguments: date
+    source: |
+      if date.wday == 1
+        date += 1
+        date
+      else
+        date
+      end
 
 tests:
   - given:

--- a/au.yaml
+++ b/au.yaml
@@ -192,12 +192,16 @@ months:
   - name: Boxing Day # BOXING DAY STATIC ACTUAL - Recognised by ALL states expect for NT/SA
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
-  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day to after christmas day even if it falls on Monday
-    regions: [au_nt, au_sa]
+  - name: Boxing Day # BOXING DAY NT SUBSTITUTE - NT substitutes boxing day to after christmas day even if it falls on Monday
+    regions: [au_nt]
     mday: 26
     function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
+  - name: Boxing Day # BOXING DAY SA SUBSTITUTE - SA only substitutes Boxing Day if it falls on a Monday
+    regions: [au_sa]
+    mday: 26
+    function: to_tuesday_if_monday(date)
   - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
-    regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
+    regions: [au_act, au_nsw, au_qld, au_vic, au_wa, au_sa]
     mday: 26
     function: additional_holiday_if_on_weekend(date)
   - name: Boxing Day # BOXING DAY OBSERVED - Only NT & TAS as they dont have an additional observed if on weekend

--- a/au.yaml
+++ b/au.yaml
@@ -170,28 +170,28 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Day # CHRISTMAS DAY EXCLUDING SATURDAY FOR SA
+  - name: Christmas Day # CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA
     regions: [au_sa]
     mday: 25
     function: sa_christmas_exclude_saturday(date)
-  - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
+  - name: Christmas Day # CHRISTMAS DAY STATIC ACTUAL - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa, au_nt]
     mday: 25
-  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT/SA - christmas day is always on monday before boxing day in NT/SA
-    regions: [au_nt, au_sa]
-    mday: 25
-    function: additional_holiday_on_monday_if_on_weekend(date)
-  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT and SA
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - additional christmas day moves two days forward on the weekend, Recognised by ALL states expect for NT and SA
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa]
     mday: 25
     function: additional_holiday_if_on_weekend(date)
-  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day in front of christmas day instead if on the weekend
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT/SA - additional christmas day on the weekend is always on monday before boxing day in NT/SA
     regions: [au_nt, au_sa]
-    mday: 26
-    function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
+    mday: 25
+    function: additional_holiday_on_monday_if_on_weekend(date)
   - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
+  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day to monday instead of tuesday
+    regions: [au_nt, au_sa]
+    mday: 26
+    function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
   - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa, au_nt]
     mday: 26

--- a/au.yaml
+++ b/au.yaml
@@ -37,11 +37,11 @@ months:
     regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld]
     mday: 1
   - name: New Year's Day # SA and TAS move New Year's Day to monday on the weekend
-    regions: [au, au_tas, au_sa]
+    regions: [au_tas, au_sa]
     mday: 1
     function: to_monday_if_weekend(date)
   - name: Additional public holiday for New Year's Day # All states except SA and TAS have additional PH for New Year's Day
-    regions: [au_nsw, au_vic, au_act, au_sa, au_wa, au_nt, au_qld]
+    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld]
     mday: 1
     function: additional_holiday_on_monday_if_on_weekend(date)
   - name: Australia Day
@@ -177,12 +177,12 @@ months:
   - name: Christmas Day # CHRISTMAS DAY ACTUAL - Recognised by ALL states expect for NT
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa, au_nt]
     mday: 25
-  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT - christmas day is always on monday before boxing day in NT
-    regions: [au_nt]
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT/SA - christmas day is always on monday before boxing day in NT/SA
+    regions: [au_nt, au_sa]
     mday: 25
     function: additional_holiday_on_monday_if_on_weekend(date)
-  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT
-    regions: [au_act, au_nsw, au_qld, au_sa, au_tas, au_vic, au_wa]
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - Recognised by ALL states expect for NT and SA
+    regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa]
     mday: 25
     function: additional_holiday_if_on_weekend(date)
   - name: Boxing Day # BOXING DAY NT SUBSTITUTE - NT substitutes boxing day in front of christmas day instead if on the weekend

--- a/au.yaml
+++ b/au.yaml
@@ -170,7 +170,7 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Day # SA CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA
+  - name: Christmas Day # SA CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA, is moved to monday
     regions: [au_sa]
     mday: 25
     function: sa_christmas_exclude_saturday(date)
@@ -181,10 +181,14 @@ months:
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa]
     mday: 25
     function: additional_holiday_if_on_weekend(date)
-  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT/SA - additional christmas day on the weekend is always on monday before boxing day in NT/SA
-    regions: [au_nt, au_sa]
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR NT - additional christmas day on the weekend is always on monday before boxing day in NT
+    regions: [au_nt]
     mday: 25
     function: additional_holiday_on_monday_if_on_weekend(date)
+  - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY TO MONDAY FOR SA EXCEPT ON SATURDAY - additional christmas day for SA excludes saturday
+    regions: [au_sa]
+    mday: 25
+    function: additional_holiday_on_monday_if_on_sunday(date)
   - name: Boxing Day # BOXING DAY STATIC ACTUAL - Recognised by ALL states expect for NT/SA
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
@@ -331,11 +335,22 @@ methods:
       else
         nil
       end
+  additional_holiday_on_monday_if_on_sunday:
+    # SA doesn't get an additional christmas day if it falls on a saturday
+    arguments: date
+    source: |
+      if date.wday == 0
+        date += 1
+        date
+      else
+        nil
+      end
   sa_christmas_exclude_saturday:
     arguments: date
     source: |
       if date.wday == 6
-        nil
+        date += 2
+        date
       else
         date
       end

--- a/au.yaml
+++ b/au.yaml
@@ -185,8 +185,8 @@ months:
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa]
     mday: 25
     function: additional_holiday_if_on_weekend(date)
-  - name: Boxing Day # BOXING DAY NT SUBSTITUTE - NT substitutes boxing day in front of christmas day instead if on the weekend
-    regions: [au_nt]
+  - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day in front of christmas day instead if on the weekend
+    regions: [au_nt, au_sa]
     mday: 26
     function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
   - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
@@ -197,7 +197,7 @@ months:
     mday: 26
     function: additional_holiday_if_on_weekend(date)
   - name: Boxing Day # BOXING DAY OBSERVED - Only NT & TAS as they dont have an additional observed if on weekend
-    regions: [au_tas, au_sa] # SA to be moved to additional setup in 2021 (2020 has no additionals)
+    regions: [au_tas] # SA to be moved to additional setup in 2021 (2020 has no additionals)
     mday: 26
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
   - name: Proclamation Day

--- a/au.yaml
+++ b/au.yaml
@@ -339,7 +339,18 @@ methods:
       else
         date
       end
-      
+  to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday: # NT has boxing day on tuesday if on monday instead
+    arguments: date
+    source: |
+      if date.wday == 6
+        date += 2
+        date
+      elsif [0,1].include?(date.wday)
+        date += 1
+        date
+      else
+        date
+      end
 
 tests:
   - given:

--- a/au.yaml
+++ b/au.yaml
@@ -170,11 +170,11 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Day # CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA
+  - name: Christmas Day # SA CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA
     regions: [au_sa]
     mday: 25
     function: sa_christmas_exclude_saturday(date)
-  - name: Christmas Day # CHRISTMAS DAY STATIC ACTUAL - Recognised by ALL states expect for NT
+  - name: Christmas Day # CHRISTMAS DAY STATIC ACTUAL - Recognised by ALL states expect for SA
     regions: [au_act, au_nsw, au_qld, au_tas, au_vic, au_wa, au_nt]
     mday: 25
   - name: Additional public holiday for Christmas Day # ADDITIONAL CHRISTMAS DAY - additional christmas day moves two days forward on the weekend, Recognised by ALL states expect for NT and SA
@@ -185,7 +185,7 @@ months:
     regions: [au_nt, au_sa]
     mday: 25
     function: additional_holiday_on_monday_if_on_weekend(date)
-  - name: Boxing Day # BOXING DAY ACTUAL - Recognised by ALL states expect for NT
+  - name: Boxing Day # BOXING DAY STATIC ACTUAL - Recognised by ALL states expect for NT/SA
     regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
   - name: Boxing Day # BOXING DAY NT/SA SUBSTITUTE - NT/SA substitutes boxing day to after christmas day even if it falls on Monday
@@ -193,7 +193,7 @@ months:
     mday: 26
     function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
   - name: Additional public holiday Boxing Day # ADDITIONAL BOXING DAY - Recognised by ALL states expect for NT / TAS
-    regions: [au_act, au_nsw, au_qld, au_vic, au_wa, au_nt]
+    regions: [au_act, au_nsw, au_qld, au_vic, au_wa]
     mday: 26
     function: additional_holiday_if_on_weekend(date)
   - name: Boxing Day # BOXING DAY OBSERVED - Only NT & TAS as they dont have an additional observed if on weekend


### PR DESCRIPTION
Have changed a few things:

NT: The additional Christmas day will fall on Monday if on Sunday (instead of Tuesday)

SA: Christmas day is substituted if it falls on a Saturday

NSW, VIC, ACT, WA, NT, QLD: New year’s day will always fall on 1st Jan, with additional holiday added on the next Monday if it falls on a weekend.

NT: Boxing day is substituted to Tuesday if it falls on Sunday or Monday, and moves to Monday if on Saturday

SA: Boxing day is substituted to Tuesday if it falls on Monday

SA: There is no additional Christmas public holiday if it falls on a Saturday
