### PR TITLE
PFC-4385 (fix) Matariki PH to the second nz yaml

### DIFF
--- a/nz2_calendar_dates.yaml
+++ b/nz2_calendar_dates.yaml
@@ -33,6 +33,9 @@ months:
     regions: [nz2_calendar_dates]
     week: 1
     wday: 1
+  - name: Matariki Holiday
+    regions: [nz2_calendar_dates]
+    function: matariki_holiday(year)
   10:
   - name: Labour Day
     regions: [nz2_calendar_dates]
@@ -115,3 +118,73 @@ tests:
       regions: ["nz2_calendar_dates"]
     expect:
       name: "Waitangi Day"
+
+methods:
+  matariki_holiday:
+    arguments: year
+    source: |
+      case year
+      when 2022
+        Date.civil(2022, 6, 24)
+      when 2023
+        Date.civil(2023, 7, 14)
+      when 2024
+        Date.civil(2024, 6, 28)
+      when 2025
+        Date.civil(2025, 6, 20)
+      when 2026
+        Date.civil(2026, 7, 10)
+      when 2027
+        Date.civil(2027, 6, 25)
+      when 2028
+        Date.civil(2028, 7, 14)
+      when 2029
+        Date.civil(2029, 7, 6)
+      when 2030
+        Date.civil(2030, 6, 21)
+      when 2031
+        Date.civil(2031, 7, 11)
+      when 2032
+        Date.civil(2032, 7, 2)
+      when 2033
+        Date.civil(2033, 6, 24)
+      when 2034
+        Date.civil(2034, 7, 7)
+      when 2035
+        Date.civil(2035, 6, 29)
+      when 2036
+        Date.civil(2036, 7, 21)
+      when 2037
+        Date.civil(2037, 7, 10)
+      when 2038
+        Date.civil(2038, 6, 25)
+      when 2039
+        Date.civil(2039, 7, 15)
+      when 2040
+        Date.civil(2040, 7, 6)
+      when 2041
+        Date.civil(2041, 7, 19)
+      when 2042
+        Date.civil(2042, 7, 11)
+      when 2043
+        Date.civil(2043, 7, 3)
+      when 2044
+        Date.civil(2044, 6, 24)
+      when 2045
+        Date.civil(2045, 7, 7)
+      when 2046
+        Date.civil(2046, 6, 29)
+      when 2047
+        Date.civil(2047, 7, 19)
+      when 2048
+        Date.civil(2048, 7, 3)
+      when 2049
+        Date.civil(2049, 6, 25)
+      when 2050
+        Date.civil(2050, 7, 15)
+      when 2051
+        Date.civil(2051, 6, 30)
+      when 2052
+        Date.civil(2052, 6, 25)
+      end
+      


### PR DESCRIPTION
## Description of changes

Added Matariki Public Holiday. Link to government website [here](https://www.mbie.govt.nz/assets/matariki-dates-2022-to-2052-matariki-advisory-group.pdf).

## Notes for code reviewers

There was no way of writing a method for these days so they were hard coded into the file.

This is for the second NZ yaml file. Domino's NZ use both the Monday-ised and normal PH's. So copying the cody from the other NZ yaml file.