### PR TITLE
PFC-4532 (fix) 2022 AFL Grand Final VIC

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -180,10 +180,6 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Eve
-    regions: [au_sa, au_nt, au_qld]
-    mday: 24
-    function: christmas_eve_part_day
   - name: Christmas Day # SA CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA, is moved to monday
     regions: [au_sa]
     mday: 25
@@ -391,12 +387,7 @@ methods:
       else
         date
       end
-  christmas_eve_part_day:
-    source: |
-      1800 till 1200
-      end
-    
-
+      
 tests:
   - given:
       date: '2020-04-25'

--- a/au.yaml
+++ b/au.yaml
@@ -387,6 +387,7 @@ methods:
       else
         date
       end
+
 tests:
   - given:
       date: '2020-04-25'

--- a/au.yaml
+++ b/au.yaml
@@ -387,7 +387,6 @@ methods:
       else
         date
       end
-      
 tests:
   - given:
       date: '2020-04-25'

--- a/au.yaml
+++ b/au.yaml
@@ -180,6 +180,10 @@ months:
     week: 1
     wday: 2
   12:
+  - name: Christmas Eve
+    regions: [au_sa, au_nt, au_qld]
+    mday: 24
+    function: christmas_eve_part_day
   - name: Christmas Day # SA CHRISTMAS DAY STATIC EXCEPT SATURDAY - Excluding Saturday for SA, is moved to monday
     regions: [au_sa]
     mday: 25
@@ -237,6 +241,8 @@ methods:
         Date.civil(2020, 10, 23)
       when 2021
         Date.civil(2021, 9, 24)
+      when 2022
+        Date.civil(2022, 9, 23)
       end
   qld_queens_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
@@ -385,6 +391,11 @@ methods:
       else
         date
       end
+  christmas_eve_part_day:
+    source: |
+      1800 till 1200
+      end
+    
 
 tests:
   - given:
@@ -647,6 +658,11 @@ tests:
       name: 'Friday before the AFL Grand Final'
   - given:
       date: '2021-09-24'
+      regions: ["au_vic"]
+    expect:
+      name: 'Friday before the AFL Grand Final'
+  - given:
+      date: '2022-09-23'
       regions: ["au_vic"]
     expect:
       name: 'Friday before the AFL Grand Final'


### PR DESCRIPTION
Vic AFL Grand Final Public Holiday is hard coded. So I added 2022 with this PR.