### PR TITLE
PFC-4672 (fix) Mourning for Queen Elizabeth II (au only)

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -151,6 +151,12 @@ months:
     wday: 1
     year_ranges:
       - before: 2017
+  - name: Day of mourning for Queen Elizabeth II
+    regions: [au, au_nsw, au_act, au_sa, au_tas, au_vic, au_wa, au_nt, au_qld]
+    week: 4
+    wday: 4
+    year_ranges:
+      - limited: 2022
   10:
   - name: Labour Day
     regions: [au_act, au_nsw, au_sa]


### PR DESCRIPTION
Adding the public holiday for all the states and territories in Australia for the 'Day of mourning for Queen Elizabeth II' on the 22nd of September 2022.

Amended the yaml.

This PR is part of three. **Definitions** > Holidays > Payaus 