### PR TITLE
PFC-4676 (fix) Mourning for Queen Elizabeth II (nz only)

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -153,8 +153,7 @@ months:
       - before: 2017
   - name: Day of mourning for Queen Elizabeth II
     regions: [au, au_nsw, au_act, au_sa, au_tas, au_vic, au_wa, au_nt, au_qld]
-    week: 4
-    wday: 4
+    mday: 22
     year_ranges:
       - limited: 2022
   10:

--- a/nz.yaml
+++ b/nz.yaml
@@ -74,6 +74,11 @@ months:
     regions: [nz_sc]
     week: 4
     wday: 1
+  - name: Day of mourning for Queen Elizabeth II
+    regions: [nz]
+    mday: 26
+    year_ranges:
+      - limited: 2022
   10:
   - name: Hawke's bay Anniversary Day
     regions: [nz_hb]

--- a/nz2_calendar_dates.yaml
+++ b/nz2_calendar_dates.yaml
@@ -36,6 +36,12 @@ months:
   - name: Matariki Holiday
     regions: [nz2_calendar_dates]
     function: matariki_holiday(year)
+  9:
+  - name: Day of mourning for Queen Elizabeth II
+    regions: [nz2_calendar_dates]
+    mday: 26
+    year_ranges:
+      - limited: 2022
   10:
   - name: Labour Day
     regions: [nz2_calendar_dates]


### PR DESCRIPTION
Adding the public holiday for both the NZ pubic holidays pushed to Monday and the others for the 'Day of mourning for Queen Elizabeth II' on the 26th of September 2022.

Amended the yaml. I also fixed the Aus one to not refer to week and day but just `mday:22`

This PR is part of three. **Definitions** > Holidays > Payaus 