### PR TITLE
PFC-4905 (fix) Additional days for Norfolk Island

### DIFF
--- a/nf.yaml
+++ b/nf.yaml
@@ -68,7 +68,7 @@ months:
   - name: (additional day Christmas Day)
     regions: [nf]
     mday: 25
-    function: to_tuesday_if_sunday_or_monday(date)
+    function: to_tuesday_if_sunday(date)
   - name: Boxing Day
     regions: [nf]
     mday: 26
@@ -79,14 +79,11 @@ methods:
     source: |
       second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, :saturday))
       second_sat_in_jun + 2
-  to_tuesday_if_sunday_or_monday:
+  to_tuesday_if_sunday:
     arguments: date
     source: |
       if [6,0].include?(date.wday)
         date += 2
-        date
-      elsif date.wday == 1
-        date += 1
         date
       else
         nil

--- a/nf.yaml
+++ b/nf.yaml
@@ -68,14 +68,10 @@ months:
   - name: (additional day Christmas Day)
     regions: [nf]
     mday: 25
-    observed: to_monday_if_weekend(date)
+    function: to_tuesday_if_sunday_or_monday(date)
   - name: Boxing Day
     regions: [nf]
     mday: 26
-  - name: (additional day Boxing Day)
-    regions: [nf]
-    mday: 26
-    function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
 
 methods:
   monday_after_second_saturday:
@@ -83,7 +79,7 @@ methods:
     source: |
       second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, :saturday))
       second_sat_in_jun + 2
-  to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday:
+  to_tuesday_if_sunday_or_monday:
     arguments: date
     source: |
       if [6,0].include?(date.wday)

--- a/nf.yaml
+++ b/nf.yaml
@@ -75,7 +75,7 @@ months:
   - name: (additional day Boxing Day)
     regions: [nf]
     mday: 26
-    observed: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday
+    function: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)
 
 methods:
   monday_after_second_saturday:

--- a/nf.yaml
+++ b/nf.yaml
@@ -7,6 +7,7 @@
 # - https://publicholidays.asia/norfolk-island/2019-dates/
 # - https://publicholidays.asia/norfolk-island/2020-dates/
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Norfolk_Island
+# -
 ---
 months:
   0:
@@ -22,6 +23,10 @@ months:
   - name: New Year's Day
     regions: [nf]
     mday: 1
+  - name: (additional day New Year's Day)
+    regions: [nf]
+    mday: 1
+    observed: to_monday_if_weekend(date)
   - name: Australia Day
     regions: [nf]
     mday: 26
@@ -30,6 +35,10 @@ months:
   - name: Foundation Day
     regions: [nf]
     mday: 6
+  - name: (additional day Foundation Day)
+    regions: [nf]
+    mday: 6
+    observed: to_monday_if_weekend(date)
   4:
   - name: Anzac Day
     regions: [nf]
@@ -50,13 +59,16 @@ months:
   11:
   - name: Thanksgiving Day
     regions: [nf]
-    week: 4
+    week: 5
     wday: 3
   12:
   - name: Christmas Day
     regions: [nf]
     mday: 25
   - name: Boxing Day
+    regions: [nf]
+    mday: 26
+  - name: (additional day Boxing Day)
     regions: [nf]
     mday: 26
     observed: to_monday_if_weekend(date)

--- a/nf.yaml
+++ b/nf.yaml
@@ -93,7 +93,7 @@ methods:
         date += 1
         date
       else
-        date
+        nil
       end
 
 tests:

--- a/nf.yaml
+++ b/nf.yaml
@@ -72,6 +72,10 @@ months:
   - name: Boxing Day
     regions: [nf]
     mday: 26
+  - name: (additional day Boxing Day)
+    regions: [nf]
+    mday: 26
+    observed: to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday
 
 methods:
   monday_after_second_saturday:
@@ -79,6 +83,18 @@ methods:
     source: |
       second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, :saturday))
       second_sat_in_jun + 2
+  to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday:
+    arguments: date
+    source: |
+      if [6,0].include?(date.wday)
+        date += 2
+        date
+      elsif date.wday == 1
+        date += 1
+        date
+      else
+        date
+      end
 
 tests:
   - given:

--- a/nf.yaml
+++ b/nf.yaml
@@ -65,13 +65,13 @@ months:
   - name: Christmas Day
     regions: [nf]
     mday: 25
+  - name: (additional day Christmas Day)
+    regions: [nf]
+    mday: 25
+    observed: to_monday_if_weekend(date)
   - name: Boxing Day
     regions: [nf]
     mday: 26
-  - name: (additional day Boxing Day)
-    regions: [nf]
-    mday: 26
-    observed: to_monday_if_weekend(date)
 
 methods:
   monday_after_second_saturday:


### PR DESCRIPTION
## Description of changes

Link to [PFC-4905 here](https://tandadocs.atlassian.net/browse/PFC-4905).

This PR is to add public holidays to the the Norfolk Island list.

2022 dates:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/19569654/202183334-cfcdebf8-b8fd-4ce2-b2d5-b4f8b3ba6692.png">

2023 dates:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/19569654/202183385-63784cf5-c14d-4053-b6b6-94ab3c611bd5.png">

## Notes for code reviewers

Each new day calls the `observed: to_monday_if_weekend(date)` meaning that if this public holiday falls on the weekend they'll get an extra day. Otherwise this method will give us nil so it will never double up if the public holiday is on a weekday.

Made a special function for the observed Christmas day to jump from sunday to tuesday. Only applies when Christmas falls on Sunday.

## Notes for testing

Will get all three repo's in sync so will test on the dev server in Payaus repo.