### PR TITLE
PFC-4946 (fix) SA to get New Years day and observed 

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -103,7 +103,7 @@ Then the holiday will be returned. This is especially useful for holidays like "
 
 ### Year ranges
 
-Certain holidays in various countries are only in effect during specific year ranges. For example, a new holiday might come into effect that is only valid after a specific year (say, 2017).
+Certain holidays in various countries are only in effect during specific year ranges. For example, a new holiday might come into effect that is only valid after a specific year (say, 2017). After is inclusive, if you put after: 2017 it will apply on 2017 and after.
 
 To address this we have the ability to specify these 'year ranges' in the definition. The gem will then only return a match on a date that adheres to these rules.
 

--- a/au.yaml
+++ b/au.yaml
@@ -50,7 +50,7 @@ months:
     regions: [au_sa]
     mday: 1
     year_ranges:
-      - after: 2022
+      - after: 2023
   - name: New Year's Day # TAS move New Year's Day to monday on the weekend
     regions: [au_tas]
     mday: 1

--- a/au.yaml
+++ b/au.yaml
@@ -43,15 +43,15 @@ months:
     regions: [au_vic]
     function: afl_grand_final(year)
   1:
-  - name: New Year's Day # All states except SA and TAS have an additional public holiday for New Year's Day
-    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld]
+  - name: New Year's Day # All states except TAS have an additional public holiday for New Year's Day
+    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld, au_sa]
     mday: 1
-  - name: New Year's Day # SA and TAS move New Year's Day to monday on the weekend
-    regions: [au_tas, au_sa]
+  - name: New Year's Day # TAS move New Year's Day to monday on the weekend
+    regions: [au_tas]
     mday: 1
     function: to_monday_if_weekend(date)
-  - name: Additional public holiday for New Year's Day # All states except SA and TAS have additional PH for New Year's Day
-    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld]
+  - name: Additional public holiday for New Year's Day # All states except TAS have additional PH for New Year's Day
+    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld, au_sa]
     mday: 1
     function: additional_holiday_on_monday_if_on_weekend(date)
   - name: Australia Day

--- a/au.yaml
+++ b/au.yaml
@@ -44,8 +44,13 @@ months:
     function: afl_grand_final(year)
   1:
   - name: New Year's Day # All states except TAS have an additional public holiday for New Year's Day
-    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld, au_sa]
+    regions: [au_nsw, au_vic, au_act, au_wa, au_nt, au_qld]
     mday: 1
+  - name: New Year's Day # SA only just get this now. Can delete after this year.
+    regions: [au_sa]
+    mday: 1
+    year_ranges:
+      - after: 2022
   - name: New Year's Day # TAS move New Year's Day to monday on the weekend
     regions: [au_tas]
     mday: 1


### PR DESCRIPTION
## Description of changes

Link to [PFC-4946 here](https://tandadocs.atlassian.net/browse/PFC-4946).

Adding the public holiday for SA to have both the day of and the observed day for New Years. 

Confirmation of these days can be found on the Fairwork Australia website here: https://www.fairwork.gov.au/employment-conditions/public-holidays/2023-public-holidays#SA

## Notes for code reviewers

Usual update process for Public Holidays. This PR is part of three. Definitions > Holidays > **Payaus**.

Ran a `bundle exec tapioca gem holidays` after updating the gem files. First commit is for testing, second will be after the Definitions and Holidays repo's have merged PR's.

The logic for this day and the observed day is used for nearly every other state. So I've just removed SA from the method that only gives them the observed day on a weekday.

## Notes for testing

- [x] Testing on the dev server to check the public holiday applies on the 1st of Jan and the 2nd of Jan as an observed day.
- [x] Make sure this only applies from 2023 and onwards

![image](https://user-images.githubusercontent.com/19569654/205191033-06ec2e48-cbfd-4406-bd8a-42974363999e.png)
---