### PR TITLE
L2S-111 - Add St Brigids Day as Irish Bank holiday

### DIFF
--- a/ie.yaml
+++ b/ie.yaml
@@ -17,6 +17,10 @@ months:
     regions: [ie]
     mday: 1
     observed: to_monday_if_weekend(date)
+  2:
+  - name: St Brigid's Day
+    regions: [ie]
+    mday: 6
   3:
   - name: St. Patrick's Day
     regions: [ie]
@@ -58,6 +62,11 @@ tests:
       regions: ["ie"]
     expect:
       name: "New Year's Day"
+  - given:
+      date: '2023-02-06'
+      regions: ["ie"]
+    expect:
+      name: "St Brigid's Day"
   - given:
       date: '2008-03-17'
       regions: ["ie"]


### PR DESCRIPTION
Add St Brigids day as Irish Bank Holiday

https://tandadocs.atlassian.net/browse/L2S-111