### PR TITLE
L2S-2153 - Remove 1st of Jan from ES PH

### DIFF
--- a/es.yaml
+++ b/es.yaml
@@ -29,6 +29,8 @@ months:
     regions: [es]
     mday: 1
     observed: to_monday_if_sunday(date)
+    year_ranges:
+      - before: 2023
   - name: Día de Reyes
     regions: [es]
     mday: 6


### PR DESCRIPTION
Removing 1st of Jan from ES public holidays as of 2023

https://tandadocs.atlassian.net/browse/L2S-2153