### PR TITLE
(Hotfix) (PFC-4972) Correct public holiday for Malaysia to be first Monday of June

### DIFF
--- a/my.yaml
+++ b/my.yaml
@@ -22,7 +22,8 @@ months:
   6:
   - name: Agong's Birthday
     regions: [my]
-    mday: 4
+    week: 1
+    wday: 1
     observed: to_weekday_if_weekend(date)
   8:
   - name: Independence Day


### PR DESCRIPTION
Ticket: https://tandadocs.atlassian.net/browse/PFC-4972
Corrected public holiday for Malaysia to fall on the first Monday of June