### PR TITLE
L2S-3557 - Update St Brigids Day IE Bank Holiday Date

### DIFF
--- a/ie.yaml
+++ b/ie.yaml
@@ -20,7 +20,7 @@ months:
   2:
   - name: St Brigid's Day
     regions: [ie]
-    mday: 6
+    mday: 5
   3:
   - name: St. Patrick's Day
     regions: [ie]


### PR DESCRIPTION
https://tandadocs.atlassian.net/browse/L2S-3557
In our system St Brigids day is showing as the 6th of February, but it should be the 5th. Changing in this PR.