### PR TITLE
hotfix: update a keyword to be correct

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -29,7 +29,7 @@ months:
     regions: [au_sa]
     function: easter(year)
     year_ranges:
-      from: 2024
+      - after: 2024
   - name: Easter Sunday
     regions: [au_wa]
     function: easter(year)


### PR DESCRIPTION
I quite literally added the incorrect keyword for checking when the holiday was meant to start from.