### PR TITLE
Changes to public holidays for Singapore and Ireland

### DIFF
--- a/ie.yaml
+++ b/ie.yaml
@@ -20,7 +20,8 @@ months:
   2:
   - name: St Brigid's Day
     regions: [ie]
-    mday: 5
+    mday: 1
+    observed: to_monday_if_not_monday_or_friday(date)
   3:
   - name: St. Patrick's Day
     regions: [ie]
@@ -179,3 +180,10 @@ tests:
       options: ["observed"]
     expect:
       name: "St. Stephen's Day"
+  - given:
+      date: '2025-02-03'
+      regions: ["ie"]
+      options: ["observed"]
+    expect:
+      name: St Brigid's Day
+

--- a/sg.yaml
+++ b/sg.yaml
@@ -13,11 +13,11 @@ months:
     regions: [sg]
     function: easter(year)
     function_modifier: -2
-  - name: Lunar New Year's Day
+  - name: Chinese New Year
     regions: [sg]
     function: cn_new_lunar_day(year)
     observed: to_monday_if_sunday(date)
-  - name: The second day of Lunar New Year
+  - name: The second day of Chinese New Year
     regions: [sg]
     function: cn_new_lunar_day(year)
     function_modifier: 1
@@ -231,13 +231,13 @@ tests:
       regions: ["sg"]
       options: ["observed"]
     expect:
-      name: "Lunar New Year's Day"
+      name: "Chinese New Year"
   - given:
       date: '2016-02-09'
       regions: ["sg"]
       options: ["observed"]
     expect:
-      name: "The second day of Lunar New Year"
+      name: "The second day of Chinese New Year"
   - given:
       date: '2077-11-15'
       regions: ["sg"]


### PR DESCRIPTION
https://tandadocs.atlassian.net/browse/L2S-3600?focusedCommentId=85958 - L2S-3600

Singapore accounts wanted Lunar new year to be renamed to Chinese New year

Ireland reported that St Brigid's day for next year is incorrect, St Brigids day public holiday lands on the first Monday in February unless the !st of Feb is Friday, in which case it will be Friday. Made changes to handle this.