### PR TITLE
Remove Palmesøndag from Denmark and Norway 

### DIFF
--- a/dk.yaml
+++ b/dk.yaml
@@ -13,11 +13,6 @@ months:
     function: easter(year)
     function_modifier: -49
     type: informal
-  - name: Palmesøndag
-    regions: [dk]
-    function: easter(year)
-    function_modifier: -7
-    type: informal
   - name: Skærtorsdag
     regions: [dk]
     function: easter(year)

--- a/no.yaml
+++ b/no.yaml
@@ -12,7 +12,6 @@ months:
     function: easter(year)
     function_modifier: -49
     type: informal
-    function_modifier: -7
   - name: Skjærtorsdag
     regions: ["no"]
     function: easter(year)

--- a/no.yaml
+++ b/no.yaml
@@ -12,9 +12,6 @@ months:
     function: easter(year)
     function_modifier: -49
     type: informal
-  - name: Palmesøndag
-    regions: ["no"]
-    function: easter(year)
     function_modifier: -7
   - name: Skjærtorsdag
     regions: ["no"]
@@ -119,12 +116,6 @@ tests:
       options: ["informal"]
     expect:
       name: "Fastelavn"
-  - given:
-      date: '2010-03-28'
-      regions: ["no"]
-      options: ["informal"]
-    expect:
-      name: "Palmesøndag"
   - given:
       date: '2010-04-01'
       regions: ["no"]


### PR DESCRIPTION
Palmesøndag is no longer a holiday and is now being removed bye bye