### PR TITLE
Add additional ANZAC Day public holiday for ACT (2026)

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -121,10 +121,15 @@ months:
     mday: 25
     year_ranges:
       - after: 2026
-  - name: ANZAC Day
+  - name: ANZAC Day # ANZAC DAY ACTUAL
     regions: [au_act]
     mday: 25
-    observed: to_monday_if_weekend(date)
+    year_ranges:
+      - limited: 2026
+  - name: Additional public holiday for ANZAC Day
+    regions: [au_act]
+    mday: 25
+    function: additional_anzac_on_monday_if_on_weekend(date)
     year_ranges:
       - limited: 2026
   - name: ANZAC Day
@@ -518,11 +523,17 @@ tests:
     expect:
       name: 'ANZAC Day'
   - given:
-      date: ['2026-04-27']
+      # ACT 2026: actual day is a public holiday
+      date: ['2026-04-25']
       regions: ["au_act"]
-      options: ["observed"]
     expect:
       name: 'ANZAC Day'
+  - given:
+      # ACT 2026: additional public holiday on Monday
+      date: ['2026-04-27']
+      regions: ["au_act"]
+    expect:
+      name: 'Additional public holiday for ANZAC Day'
   - given:
       # QLD: stays on 25th (only moves if Sunday)
       date: ['2026-04-25', '2028-04-25', '2029-04-25', '2030-04-25', '2031-04-25', '2033-04-25', '2034-04-25', '2035-04-25']


### PR DESCRIPTION
## Summary
- Adds both the actual ANZAC Day (Apr 25) and the additional public holiday (Monday Apr 27) for ACT in 2026
- Previously only the observed Monday was defined, missing the actual date as a holiday
- Uses existing `additional_anzac_on_monday_if_on_weekend` function, matching the pattern used by NSW and WA

## Test plan
- [x] `make validate` passes
- [x] Tests updated for both ACT dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)