### PR TITLE
Add Juneteenth to federal_reserve region

### DIFF
--- a/federal_reserve.yaml
+++ b/federal_reserve.yaml
@@ -25,6 +25,11 @@ months:
     week: -1
     wday: 1
     regions: [federal_reserve]
+  6:
+  - name: Juneteenth National Independence Day
+    regions: [federal_reserve]
+    mday: 19
+    observed: to_monday_if_sunday(date)
   7:
   - name: Independence Day
     regions: [federal_reserve]
@@ -356,3 +361,21 @@ tests:
       options: ["observed"]
     expect:
       name: "Christmas Day"
+  - given:
+      date: '2022-06-20'
+      regions: ["federal_reserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
+  - given:
+      date: '2023-06-19'
+      regions: ["federal_reserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
+  - given:
+      date: '2024-06-19'
+      regions: ["federal_reserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"


### PR DESCRIPTION
## Summary

- Adds Juneteenth National Independence Day (June 19) to the `federal_reserve` region
- Uses the standard `to_monday_if_sunday(date)` observance rule, matching how the Fed observes other fixed-date federal holidays
- Adds test cases for 2022 (Sun → Mon observance), 2023 (Mon literal), and 2024 (Wed literal)

## Why

Juneteenth became a federal holiday in 2021 (Juneteenth National Independence Day Act, Pub. L. 117-17). The Federal Reserve observes it as a closure day, but the upstream `holidays/holidays` gem hasn't added it to the `:federal_reserve` region — and our fork inherited the same gap. This causes downstream banking-day calculations to incorrectly treat June 19 as an open day.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/defs/test_defs_federal_reserve.rb` passes after regenerating from the new YAML (verified in the corresponding `TandaHQ/holidays` PR)