### PR TITLE
Add observed rule to US Independence Day and Utah Pioneer Day

### DIFF
--- a/us.yaml
+++ b/us.yaml
@@ -212,6 +212,7 @@ months:
   - name: Independence Day # fixed
     regions: [us]
     mday: 4
+    observed: to_weekday_if_weekend(date)
   - name: Independence Day (Holiday)
     regions: [us_va]
     mday: 4
@@ -219,6 +220,7 @@ months:
   - name: Pioneer Day # fixed
     regions: [us_ut]
     mday: 24
+    observed: to_weekday_if_weekend(date)
   8:
   - name: Victory Day # Second Monday in August
     regions: [us_ri]
@@ -740,8 +742,20 @@ tests:
     expect:
       name: "Independence Day (Holiday)"
   - given:
+      date: ['2020-7-3', '2021-7-5', '2026-7-3']
+      regions: ["us"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
       date: ['2020-7-24']
       regions: ["us_ut"]
+    expect:
+      name: "Pioneer Day"
+  - given:
+      date: ['2021-7-23', '2022-7-25']
+      regions: ["us_ut"]
+      options: ["observed"]
     expect:
       name: "Pioneer Day"
 


### PR DESCRIPTION
## Summary

- Adds `observed: to_weekday_if_weekend(date)` to **Independence Day** (`mday: 4`, region `us`)
- Adds `observed: to_weekday_if_weekend(date)` to **Pioneer Day** (`mday: 24`, region `us_ut`)
- Adds test cases asserting Sat→Fri / Sun→Mon shifts when `:observed` is passed

## Why

**Independence Day (federal):** Every other fixed-date federal `:us` holiday in this file already carries the standard `to_weekday_if_weekend(date)` observed rule — New Year's Day, Juneteenth, Veterans Day, Christmas Day. Independence Day is the only one missing it, which means consumers passing `:observed` still get the literal Saturday/Sunday date for July 4. Under 5 USC § 6103(b), federal employees observe Independence Day on the nearest weekday when it falls on a weekend, and most US employers follow the same convention.

**Pioneer Day (Utah):** Utah Code § 63G-1-301 specifies that state holidays falling on Saturday are observed the preceding Friday, and those falling on Sunday are observed the following Monday. Pioneer Day (July 24) is a Utah state holiday that should shift accordingly. The existing entry has no observed rule, so consumers get the literal date even with `:observed` passed.

Note that the `us_va` "Independence Day (Holiday)" entry already uses `function: to_weekday_if_weekend(date)`, which unconditionally shifts. The new `observed:` rules differ in that callers must opt in via `:observed` — preserving backward compatibility for any consumer querying the literal calendar date.

## Test plan

- [x] `make validate` passes
- [x] `make test` passes (50 examples, 0 failures)
- [x] New test fixtures cover both Sat→Fri (Independence Day 2020/2026, Pioneer Day 2021) and Sun→Mon (Independence Day 2021, Pioneer Day 2022) shifts
- [ ] Downstream `TandaHQ/holidays` PR will regenerate definitions and run the full test suite against the new fixtures