### PR TITLE
Change NZ Queens Birthday to Kings Birthday

### DIFF
--- a/nz.yaml
+++ b/nz.yaml
@@ -66,6 +66,14 @@ months:
     regions: [nz]
     week: 1
     wday: 1
+    year_ranges:
+      - before: 2022
+  - name: King's Birthday
+    regions: [nz]
+    week: 1
+    wday: 1
+    year_ranges:
+      - after: 2023
   - name: Matariki Holiday
     regions: [nz]
     function: matariki_holiday(year)
@@ -258,6 +266,16 @@ tests:
       options: ["observed"]
     expect:
       name: "Taranaki Anniversary Day"
+  - given:
+      date: ['2021-06-07', '2022-06-06']
+      regions: ["nz"]
+    expect:
+      name: "Queen's Birthday"
+  - given:
+      date: ['2023-06-05', '2024-06-03']
+      regions: ["nz"]
+    expect:
+      name: "King's Birthday"
 
 methods:
   closest_monday:

--- a/nz2_calendar_dates.yaml
+++ b/nz2_calendar_dates.yaml
@@ -33,6 +33,14 @@ months:
     regions: [nz2_calendar_dates]
     week: 1
     wday: 1
+    year_ranges:
+      - before: 2022
+  - name: King's Birthday
+    regions: [nz2_calendar_dates]
+    week: 1
+    wday: 1
+    year_ranges:
+      - after: 2023
   - name: Matariki Holiday
     regions: [nz2_calendar_dates]
     function: matariki_holiday(year)


### PR DESCRIPTION
## Description
Changes the NZ 'Queens Birthday' public holiday to the now recognized (from 2023) 'Kings Birthday' public holiday - on the same date. 