### PR TITLE
ENG-4974 Add AFL Grand Final Day 2026 for Victoria

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -339,6 +339,8 @@ methods:
         Date.civil(2024, 9, 27)
       when 2025
         Date.civil(2025, 9, 26)
+      when 2026
+        Date.civil(2026, 9, 25)
       end
   qld_kings_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
@@ -832,6 +834,11 @@ tests:
       name: 'Friday before the AFL Grand Final'
   - given:
       date: '2025-09-26'
+      regions: ["au_vic"]
+    expect:
+      name: 'Friday before the AFL Grand Final'
+  - given:
+      date: '2026-09-25'
       regions: ["au_vic"]
     expect:
       name: 'Friday before the AFL Grand Final'


### PR DESCRIPTION
## Summary
- Add Friday 25 September 2026 as the AFL Grand Final Day public holiday for Victoria (`au_vic`)
- Adds `when 2026` case to `afl_grand_final` method in `au.yaml`
- Adds corresponding test entry

## Source
[Business Victoria - Victorian Public Holidays 2026](https://business.vic.gov.au/business-information/public-holidays/victorian-public-holidays-2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)